### PR TITLE
refactor: check verification in a revertable way

### DIFF
--- a/contracts/CRW.sol
+++ b/contracts/CRW.sol
@@ -41,9 +41,9 @@ contract CRW is ERC20, Ownable, AccessControl {
     }
 
     function verify(address _costumer) public onlyRestaurant {
-        if(appointments[_costumer][msg.sender] != 0) {
-            _mint(_costumer, amount_of_token_for_book);
-        }
+        require(appointments[_costumer][msg.sender] != 0, "No appointment exists");
+        _mint(_costumer, amount_of_token_for_book);
+        
     }
 
     function setAmount(uint256 _newAmount) public onlyOwner {


### PR DESCRIPTION
It's generally a good idea to use `require` when doing such checks.

Why? Because if you used `if` it wouldn't revert the transaction and the user wouldn't know that. Using `require` inherently reverts the transaction and throws an error on the client so the user is not notified of the blockchain state not being changed.